### PR TITLE
Allow case sensitive service name.

### DIFF
--- a/aws-sign4.lisp
+++ b/aws-sign4.lisp
@@ -164,7 +164,9 @@ parameter ESCAPE% is NIL, the % is not escaped."
                                                        :timezone local-time:+utc-zone+))
              (scope-date (subseq x-amz-date 0 8))
              (region (string-downcase region))
-             (service (string-downcase service))
+             (service (etypecase service
+                        (symbol (string-downcase service))
+                        (string service)))
              (credential-scope (format nil "~A/~A/~A/aws4_request" scope-date region service)))
         (unless (get-header :host)
           (push (cons :host host) headers))


### PR DESCRIPTION
`:service` expects a string designator and will be downcased, however, it sometimes should be case sensitive.

For example, AGCOD (Amazon Gift Card On Demand) service -- it's not actually AWS service but it also adopts AWS signing -- uses `AGCODService` as a service identifier.

This patch prevents from downcasing the service name if it's a string, and still converts in case that it's a symbol (or keyword) for backward-compatibility.