### PR TITLE
Allow non-string values in params.

### DIFF
--- a/aws-sign4.lisp
+++ b/aws-sign4.lisp
@@ -68,7 +68,9 @@ parameter ESCAPE% is NIL, the % is not escaped."
 (defun create-canonical-query-string (params)
   (format nil "~{~A~^&~}"
           (sort (loop for (key . value) in params
-                      collect (format nil "~A=~A" (url-encode (string key)) (url-encode value)))
+                      collect (format nil "~A=~A"
+                                      (url-encode (string key))
+                                      (url-encode (princ-to-string value))))
                 #'string<)))
 
 (defun trimall (string)


### PR DESCRIPTION
When params contains non-string values as query parameters, `aws-sign4` raises a TYPE-ERROR.

Here's an error and stacktraces when accessing to Amazon SQS to fetch a message with `WaitTimeSeconds=10`. (See also [fukamachi/aws-sdk-lisp](https://github.com/fukamachi/aws-sdk-lisp))

```
The value
  10
is not of type
  VECTOR
when binding #:LOOP-ACROSS-VECTOR-9
   [Condition of type TYPE-ERROR]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] abort thread (#<THREAD "repl-thread" RUNNING {1002F38003}>)

Backtrace:
  0: (AWS-SIGN4::URL-ENCODE 10 :ESCAPE% T)
  1: (AWS-SIGN4:CREATE-CANONICAL-QUERY-STRING (("Action" . "ReceiveMessage") ("QueueUrl" . "http://sqs.ap-northeast-1.amazonaws.com/xxxxxxxxxxxx/test-queue") ("WaitTimeSeconds" . 10)))
  2: (AWS-SIGN4:AWS-SIGN4 :REGION "ap-northeast-1" :SERVICE "sqs" :METHOD :POST :HOST "sqs.ap-northeast-1.amazonaws.com" :PATH "/" :PARAMS (("Action" . "ReceiveMessage") ("QueueUrl" . "http://sqs.ap-northe..
  3: (AWS-SDK/API:AWS-REQUEST :PATH "/" :SERVICE "sqs" :METHOD :POST :PARAMS (("Action" . "ReceiveMessage") ("QueueUrl" . "http://sqs.ap-northeast-1.amazonaws.com/xxxxxxxxxxxx/test-queue") ("WaitTimeSeconds..
  4: (AWS-SDK/SERVICES/SQS:RECEIVE-MESSAGE :QUEUE-URL "http://sqs.ap-northeast-1.amazonaws.com/xxxxxxxxxxxx/test-queue" :WAIT-TIME-SECONDS 10)
```