### PR TITLE
Sort query parameters according to spec

### DIFF
--- a/aws-sign4.lisp
+++ b/aws-sign4.lisp
@@ -67,11 +67,10 @@ parameter ESCAPE% is NIL, the % is not escaped."
 
 (defun create-canonical-query-string (params)
   (format nil "~{~A~^&~}"
-          (sort (loop for (key . value) in params
-                      collect (format nil "~A=~A"
-                                      (url-encode (string key))
-                                      (url-encode (princ-to-string value))))
-                #'string<)))
+          (loop for (key . value) in (sort (copy-seq params) #'string< :key #'car)
+             collect (format nil "~A=~A"
+                             (url-encode (string key))
+                             (url-encode (princ-to-string value))))))
 
 (defun trimall (string)
   (string-trim '(#\Space #\Tab) string))


### PR DESCRIPTION
AWS requests were failing in certain cases, the spec for canonicalizing the query string says:

> Sort the parameter _names_ by character code point in ascending order

This PR sorts only the names and not the name+value, which made the failing requests work. (e.g. use fukamachi's aws-sdk-lisp project to list all stacks and specify more than 9 statuses in the `:stack-status-filter`