### PR TITLE
Allow pathnames for payloads

### DIFF
--- a/aws-sign4.lisp
+++ b/aws-sign4.lisp
@@ -23,7 +23,11 @@
       data))
 
 (defun hash (data)
-  (ironclad:digest-sequence :sha256 data))
+  (etypecase data
+    ((simple-array (unsigned-byte 8) (*))
+     (ironclad:digest-sequence :sha256 data))
+    (pathname
+     (ironclad:digest-file :sha256 data))))
 
 (defun hex-encode (bytes)
   (ironclad:byte-array-to-hex-string bytes))


### PR DESCRIPTION
Payloads are often large in size, and streaming would be better in those cases.

However, since aws-sign4 currently only accepts octets in the payload, the entire file needs to be loaded into memory, resulting in performance issues. `ironclad:digest-file` can be used to calculate signatures more efficiently.