### PR TITLE
Fix newline encoding on windows.

### DIFF
--- a/aws-sign4.lisp
+++ b/aws-sign4.lisp
@@ -19,7 +19,7 @@
 
 (defun ensure-octets (data)
   (if (stringp data)
-      (flex:string-to-octets data :external-format :utf-8)
+      (flex:string-to-octets data :external-format '(:utf-8 :eol-style :lf))
       data))
 
 (defun hash (data)


### PR DESCRIPTION
Flexi-streams on windows by default encodes a newline character as two bytes (CRLF), when AWS expects just LF. This changes the hash of the canonical request, so invalidates the signature.  